### PR TITLE
Don't trigger reset on full sync if silent is passed

### DIFF
--- a/js/backbone_offline.js
+++ b/js/backbone_offline.js
@@ -252,7 +252,9 @@
               regenerateId: true
             });
           }
-          _this.collection.items.trigger('reset');
+          if (!options.silent) {
+            _this.collection.items.trigger('reset');
+          }
           if (options.success) return options.success(response);
         }
       });

--- a/spec/lib/sync_spec.coffee
+++ b/spec/lib/sync_spec.coffee
@@ -45,6 +45,13 @@ describe 'Offline.Sync', ->
       @sync.full(@options)
       expect(resetCallback.callCount).toBe(1)
 
+    it 'should not reset collection if silent is passed', ->
+      resetCallback = jasmine.createSpy('-Reset Callback-')
+      @sync.collection.items.on('reset', resetCallback)
+      @options.silent = true
+      @sync.full(@options)
+      expect(resetCallback.callCount).toBe(0)
+
     it 'should not trigger "add" callbacks', ->
       addCallback = jasmine.createSpy('-Add Callback-')
       @sync.collection.items.on('add', addCallback)

--- a/src/backbone_offline.coffee
+++ b/src/backbone_offline.coffee
@@ -205,7 +205,7 @@ class Offline.Sync
       @storage.clear()
       @collection.items.reset([], silent: true)
       @collection.items.create(item, silent: true, local: true, regenerateId: true) for item in response
-      @collection.items.trigger('reset')
+      @collection.items.trigger('reset') unless options.silent
       options.success(response) if options.success
 
   # @storage.sync.incremental() - incremental storage synchronization


### PR DESCRIPTION
Can pass `silent: true` to Sync.full() to suppress the reset event.
