### PR TITLE
Reverses pull() and push() descriptions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ The default behavior: synchronization of data with a server occurs on the collec
 
 * `full()` — full collection reload
 * `incremental()` — request data from the server with `pull()` and then send changed data to the server with `push()`
-* `push()` - receive data from the server and merge with a current collection
-* `pull()` - send dirty-data to the server with an atomic operations create, update, destroy. This ensures the reliability of stored data.
+* `pull()` - receive data from the server and merge with a current collection
+* `push()` - send dirty-data to the server with an atomic operations create, update, destroy. This ensures the reliability of stored data.
 
 If you don't want to request data from server on fetch you can use option `local: true`:  `dreams.fetch(local: true)`
 


### PR DESCRIPTION
The descriptions were using the wrong function calls.
