### PR TITLE
Ajax options get lost on its way through the script.

### DIFF
--- a/js/backbone_offline.js
+++ b/js/backbone_offline.js
@@ -119,9 +119,9 @@
       if (options == null) options = {};
       if (!options.local) {
         if (this.isEmpty()) {
-          this.sync.full();
+          this.sync.full(options);
         } else {
-          this.sync.incremental();
+          this.sync.incremental(options);
         }
       }
       _ref = this.allIds.values;
@@ -260,13 +260,13 @@
       });
     };
 
-    Sync.prototype.incremental = function() {
+    Sync.prototype.incremental = function(options) {
       var _this = this;
-      return this.pull({
+      return this.pull(_.extend(options, {
         success: function() {
           return _this.push();
         }
-      });
+      }));
     };
 
     Sync.prototype.prepareOptions = function(options) {
@@ -285,7 +285,7 @@
     Sync.prototype.pull = function(options) {
       var _this = this;
       if (options == null) options = {};
-      return this.ajax('read', this.collection.items, {
+      return this.ajax('read', this.collection.items, _.extend(options, {
         success: function(response, status, xhr) {
           var item, _i, _len;
           _this.collection.destroyDiff(response);
@@ -295,7 +295,7 @@
           }
           if (options.success) return options.success();
         }
-      });
+      }));
     };
 
     Sync.prototype.pullItem = function(item) {

--- a/src/backbone_offline.coffee
+++ b/src/backbone_offline.coffee
@@ -201,18 +201,19 @@ class Offline.Sync
   # 1. clear collection and store
   # 2. load new data
   full: (options = {}) ->
-    @ajax 'read', @collection.items, success: (response, status, xhr) =>
-      @storage.clear()
-      @collection.items.reset([], silent: true)
-      @collection.items.create(item, silent: true, local: true, regenerateId: true) for item in response
-      @collection.items.trigger('reset') unless options.silent
-      options.success(response) if options.success
+    @ajax 'read', @collection.items, _.extend {}, options,
+      success: (response, status, xhr) =>
+        @storage.clear()
+        @collection.items.reset([], silent: true)
+        @collection.items.create(item, silent: true, local: true, regenerateId: true) for item in response
+        @collection.items.trigger('reset') unless options.silent
+        options.success(response) if options.success
 
   # @storage.sync.incremental() - incremental storage synchronization
   # 1. pull() - request data from server
   # 2. push() - send modified data to server
   incremental: ->
-    @pull success: => @push()
+    @pull _.extend {}, options, success: => @push()
 
   # Runs incremental sync when storage was offline
   # after current request therefore don't duplicate requests
@@ -231,10 +232,11 @@ class Offline.Sync
   #
   # @storage.sync.pull()
   pull: (options = {}) ->
-    @ajax 'read', @collection.items, success: (response, status, xhr) =>
-      @collection.destroyDiff(response)
-      @pullItem(item) for item in response
-      options.success() if options.success
+    @ajax 'read', @collection.items, _.extend {}, options,
+      success: (response, status, xhr) =>
+        @collection.destroyDiff(response)
+        @pullItem(item) for item in response
+        options.success() if options.success
 
   pullItem: (item) ->
     local = @collection.get(item.id)

--- a/src/backbone_offline.coffee
+++ b/src/backbone_offline.coffee
@@ -122,7 +122,7 @@ class Offline.Storage
   # And refreshes the storage into background
   findAll: (options = {}) ->
     unless options.local
-      if @isEmpty() then @sync.full() else @sync.incremental()
+      if @isEmpty() then @sync.full(options) else @sync.incremental(options)
     JSON.parse(@getItem("#{@name}-#{id}")) for id in @allIds.values
 
   s4: ->
@@ -212,7 +212,7 @@ class Offline.Sync
   # @storage.sync.incremental() - incremental storage synchronization
   # 1. pull() - request data from server
   # 2. push() - send modified data to server
-  incremental: ->
+  incremental:(options = {}) ->
     @pull _.extend {}, options, success: => @push()
 
   # Runs incremental sync when storage was offline


### PR DESCRIPTION
If you pass options to fetch() they get lost on its way to the final request.

For example if you have:

``` javascript
model.fetch({
   data: { action: model.methods.getAll }
});
```

you end up with a request without the parameter.
